### PR TITLE
bump botkit version to add thread support

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "node": "^4.0.0"
   },
   "dependencies": {
-    "botkit": "^0.2.0",
+    "botkit": "^0.4.10",
     "jira-client": "^3.0.2",
     "jira2slack": "^1.0.0",
     "moment": "^2.10.3",


### PR DESCRIPTION
Botkit just added support for slack threads in howdyai/botkit#609

After bumping the version, responses to posts in a thread appear in the appropriate thread instead of in the related channel.

There is a working image based on this branch up on dockerhub at `mujiburger/slack-jirabot:threads`.